### PR TITLE
refactor:실시간 알림 ui 개선 , 헤더의 알림 이모티콘 실시간 알림 시 알림있다는 표시 모양 이모티콘으로 변경, 알…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,7 @@ function App() {
       <Route path={`/dashboard/all-popular-post`} element={<AllPopularPost></AllPopularPost>} />
       <Route path={`/dashboard/all-new-post`} element={<AllNewPost></AllNewPost>} />
       <Route path={`/dashboard/all-new-notification`} element={<AllNewNotification></AllNewNotification>} />
-      <Route path={`/:nickname/:postID?`} element={<MyBlogMainPage></MyBlogMainPage>} />
+      <Route path={`/:nickname/:postID?/:commentID?/:replyID?`} element={<MyBlogMainPage></MyBlogMainPage>} />
       <Route path={`/writenewpost/:nickname`} element={<WriteNewPost></WriteNewPost>} />
       <Route path={`/getpost/:nickname`} element={<GetPost></GetPost>} />
       <Route path={`/fixpost/:nickname`} element={<FixPost></FixPost>} />

--- a/src/NotificationContext.tsx
+++ b/src/NotificationContext.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, useState, useContext, ReactNode } from 'react';
+
+// NotificationContext 생성
+interface NotificationContextType {
+  hasNoti: boolean;
+  setHasNoti: (value: boolean) => void;
+}
+
+const NotificationContext = createContext<NotificationContextType | undefined>(undefined);
+
+interface NotificationProviderProps {
+  children: ReactNode; // children 타입을 명시적으로 정의
+}
+
+// NotificationProvider 컴포넌트
+export const NotificationProvider: React.FC<NotificationProviderProps> = ({ children }) => {
+  const [hasNoti, setHasNoti] = useState<boolean>(false);
+
+  return (
+    <NotificationContext.Provider value={{ hasNoti, setHasNoti }}>
+      {children}
+    </NotificationContext.Provider>
+  );
+};
+
+// Context를 사용하는 훅
+export const useNotification = () => {
+  const context = useContext(NotificationContext);
+  if (!context) {
+    throw new Error('useNotification must be used within a NotificationProvider');
+  }
+  return context;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-
+import { NotificationProvider } from './NotificationContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <App />
+  <NotificationProvider>
+    <App />
+  </NotificationProvider>
 );
 
 

--- a/src/main/AllNewNotification.css
+++ b/src/main/AllNewNotification.css
@@ -2,5 +2,6 @@
   display: flex;
   justify-content: center; /* 버튼들을 수평으로 중앙 정렬 */
   margin-bottom: 20px; /* 아래 여백 추가 */
+  flex-wrap: wrap;
   gap: 10px; /* 버튼 사이 간격 */
 }

--- a/src/main/AllNewPost.tsx
+++ b/src/main/AllNewPost.tsx
@@ -34,7 +34,7 @@ const AllPopularPost: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [token, setToken] = useState<string>('');
   const [localNickName, setLocalNickName] = useState<string>('');
-
+  const [hasNotifications, setHasNotifications] = useState<boolean>(false);
   const pageSize = 10;
   // const [filteredPosts, setFilteredPosts] = useState<TYPES.getPost[]>([]);
   const navigate = useNavigate();
@@ -292,9 +292,12 @@ const AllPopularPost: React.FC = () => {
     const regex = new RegExp(`(${keyword})`, 'gi');
     return text.replace(regex, '<span class="highlight">$1</span>');
   };
+  const handleNotification = (isNotified: boolean) => {
+    setHasNotifications(isNotified); // 알림이 발생하면 true로 설정
+  };
   return (
     <>
-      <Header pageType="otherblog" />
+      <Header pageType="otherblog" hasNotifications ={hasNotifications}/>
       <main>
         <div className="main-container">
         {(!token && <Profile pageType="signup_for_blog" />)}
@@ -351,7 +354,7 @@ const AllPopularPost: React.FC = () => {
           
           </div>
         </div>
-        <SSEComponent></SSEComponent>
+        <SSEComponent onNotification={handleNotification}></SSEComponent>
       </main>
       <Footer />
     </>

--- a/src/main/AllPopularPost.tsx
+++ b/src/main/AllPopularPost.tsx
@@ -37,7 +37,7 @@ const AllPopularPost: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [token, setToken] = useState<string>('');
   const [localNickName, setLocalNickName] = useState<string>('');
-
+  const [hasNotifications, setHasNotifications] = useState<boolean>(false);
   const pageSize = 10;
   // const [filteredPosts, setFilteredPosts] = useState<TYPES.getPost[]>([]);
   const navigate = useNavigate();
@@ -266,7 +266,9 @@ const AllPopularPost: React.FC = () => {
     };
     
   }, []);
-
+  const handleNotification = (isNotified: boolean) => {
+    setHasNotifications(isNotified); // 알림이 발생하면 true로 설정
+  };
   useEffect(() => {
     console.log(`
       
@@ -290,7 +292,7 @@ const AllPopularPost: React.FC = () => {
 
   return (
     <>
-      <Header pageType="otherblog" />
+      <Header pageType="otherblog" hasNotifications ={hasNotifications}/>
       <main>
         <div className="main-container">
         {(!token && <Profile pageType="signup_for_blog" />)}
@@ -350,7 +352,7 @@ const AllPopularPost: React.FC = () => {
           
           </div>
         </div>
-        <SSEComponent></SSEComponent>
+        <SSEComponent onNotification={handleNotification}></SSEComponent>
       </main>
       <Footer />
     </>

--- a/src/main/Dashboard.tsx
+++ b/src/main/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect,useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Header from '../structure/Header';
 import Footer from '../structure/Footer';
@@ -16,6 +16,7 @@ import SSEComponent from './SSEComponent';
  */
 const Dashboard: React.FC = () => {
   const navigate = useNavigate();
+  const [hasNotifications, setHasNotifications] = useState<boolean>(false);
 
   useEffect(() => {
     const token = sessionStorage.getItem('accessToken');
@@ -23,9 +24,14 @@ const Dashboard: React.FC = () => {
       navigate('/');
     }
   }, [navigate]);
+
+
+  const handleNotification = (isNotified: boolean) => {
+    setHasNotifications(isNotified); // 알림이 발생하면 true로 설정
+  };
   return (
     <div className="App">
-      <Header pageType="otherblog"/>
+      <Header pageType="otherblog" hasNotifications ={hasNotifications}/>
       <main className="main-content">
         <Profile pageType="login" />
         <NewPost />
@@ -33,7 +39,7 @@ const Dashboard: React.FC = () => {
         <PopularTags/>
         <LotsOfFollowerBloger/>
         <CarrotBloger/>
-        <SSEComponent></SSEComponent>
+        <SSEComponent onNotification={handleNotification}></SSEComponent>
       </main>
       <Footer />
     </div>

--- a/src/main/MyProfileSetting.tsx
+++ b/src/main/MyProfileSetting.tsx
@@ -19,6 +19,7 @@ const MyProfileSetting: React.FC = () => {
     const [newPassword, setNewPassword] = useState<string>('');
     const [sendPassword, setSendPassword] = useState<string>('');
     const [confirmPassword, setConfirmPassword] = useState<string>('');
+    const [hasNotifications, setHasNotifications] = useState<boolean>(false);
     const [errors, setErrors] = useState({
         password: '',
         newPassword: '',
@@ -233,7 +234,9 @@ const MyProfileSetting: React.FC = () => {
     useEffect(() => {
         fetchMyProfile();
     }, [navigate]);
-
+    const handleNotification = (isNotified: boolean) => {
+        setHasNotifications(isNotified); // 알림이 발생하면 true로 설정
+      };
     useEffect(() => {
         fetchMyProfile();
     }, []);
@@ -314,7 +317,7 @@ const MyProfileSetting: React.FC = () => {
 
     return (
         <div className="App">
-            <Header pageType="profileSetting" />
+            <Header pageType="profileSetting" hasNotifications ={hasNotifications}/>
             <main className="main-container">
                
                 {/* <div className="MainPosts-section"> */}
@@ -365,7 +368,7 @@ const MyProfileSetting: React.FC = () => {
                         </div>
                    
                 {/* </div> */}
-                <SSEComponent></SSEComponent>
+                <SSEComponent onNotification={handleNotification}></SSEComponent>
             </main>
             <Footer />
         </div>

--- a/src/main/Notification.css
+++ b/src/main/Notification.css
@@ -1,4 +1,6 @@
-
+.notification-list{
+  max-width: 100%;
+}
 .modal-overlay-notification {
   position: fixed;
   top: 0;
@@ -11,32 +13,50 @@
   justify-content: center;
   z-index: 1000;
 }
+.modal-overlay-notification h3{
+  flex-wrap: nowrap;
+}
 .modal-header-notification {
   display: flex;
   justify-content: space-between; /* 두 요소를 양쪽 끝에 배치 */
   align-items: center; /* 수직 중앙 정렬 */
+  flex-wrap: nowrap;
 }
 .allLook {
+  margin-left: 10px;
   cursor: pointer;
   font-size: 14px;
   color:rgb(152, 152, 152);
-  margin-left: auto; /* 자동 왼쪽 여백으로 오른쪽 정렬 */
-  margin-right: 450px;
-}
 
+}
+.title-all{
+  display: flex;
+  align-items: center;
+}
+.noti-all{
+  max-width: 100%;
+}
+.noti-title{
+  text-overflow: ellipsis; /* 넘치는 텍스트는 말줄임표 처리 */
+  overflow: hidden; /* 태그 내용이 넘치면 잘림 방지 */
+  max-width: 50%;
+  font-weight: bold;
+  white-space: wrap; /* 텍스트를 한 줄로 처리 */
+}
 .modal-content-notification {
+  position: fixed; /* 화면에 고정 */
+  top: 50px;       /* 화면 상단에서 20px 아래 */
+  right: 50px;     /* 화면 오른쪽에서 20px 떨어짐 */
   background-color: white;
   padding: 20px;
-  border:2px solid #FF88D7;
+  border: 2px solid #FF88D7;
   border-radius: 5px;
-  width: 80%;
-  max-width: 600px;
+  width: 80vw;     /* 너비를 화면 너비의 80%로 설정 */
+  max-width: 600px; /* 최대 너비를 600px로 제한 */
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-  position: relative;
   z-index: 1001;
-   /* 스크롤을 가능하게 하는 속성 추가 */
-  max-height: 80vh; /* 화면 높이의 80%로 제한 */
-  overflow-y: auto; /* 세로 스크롤 활성화 */
+  max-height: 80vh; /* 최대 높이를 화면 높이의 80%로 설정 */
+  overflow-y: auto; /* 내용이 넘칠 경우 스크롤 */
 }
 
 .modal-close-notification {
@@ -51,17 +71,21 @@
   justify-content: space-between;
   align-items: center;
   padding: 10px 0;
+  max-width: 100%;
 }
 
 .notification-content {
   display: flex;
   background-color: #00000000;
   align-items: center;
+  max-width: 100%;
 }
 
 .notification-trigger-image {
   width: 40px;
   height: 40px;
+  min-width: 40px;
+  min-height: 40px;
   border-radius: 50%;
   margin-right: 10px;
   border:2px solid #FF88D7;
@@ -71,6 +95,7 @@
 .notification-details {
   display: flex;
   flex-direction: column;
+  max-width: 100%;
   background-color: #00000000;
 }
 
@@ -106,4 +131,7 @@
 .notification-name{
   color: #FF6DC6;
   cursor: pointer;
+  font-weight: bold;
+  background-color: transparent;
 }
+

--- a/src/main/Notification.tsx
+++ b/src/main/Notification.tsx
@@ -22,7 +22,8 @@ interface NotificationData {
   comment_content: string | null;
   notification_board:string | null;
   notification_comment:string | null;
-
+  board_writer:string| null,
+  parent_comment_id: string | null,
 
 
 }
@@ -66,34 +67,52 @@ const Notification: React.FC<FollowModalProps> = ({ onClose, buttonRef }) => {
       case 'new-follower':
         return (
           <span style={{cursor:'pointer'}}>
-            <strong className='notification-name' onClick={()=>{navigate(`/${notification.trigger_nickname}`)}}>{notification.trigger_nickname}</strong>님이 당신을 팔로우했습니다.
+            <strong className='notification-name' onClick={()=>{navigate(`/${notification.trigger_nickname}`)}}>{notification.trigger_nickname}</strong>
+            님이 당신을 팔로우했습니다.
           </span>
         );
       case 'following-new-board':
         return (
-          <span style={{cursor:'pointer'}} onClick={()=>{goToNotificationPost(notification.trigger_nickname,notification.notification_board)}}>
-            <strong className='notification-name'>{notification.trigger_nickname}</strong>님이 새 게시글을 작성했습니다: <em>{notification.board_title}</em>
-          </span>
+          <div className='noti-all' style={{cursor:'pointer'}} 
+          onClick={()=>{goToNotificationPost(notification.trigger_nickname,notification.notification_board)}}>
+            <strong className='notification-name' onClick={()=>{navigate(`/${notification.trigger_nickname}`)}}>
+              {notification.trigger_nickname}</strong>
+            님이 새 게시글을 작성했습니다:
+             <em className='noti-title'>{truncateText(notification.board_title || '', 20)}</em>
+          </div>
         );
       case 'comment-on-board':
         return (
-          <span style={{cursor:'pointer'}} onClick={()=>{goToNotificationPost(notification.trigger_nickname,notification.notification_board)}}>
-            <strong className='notification-name' >{notification.trigger_nickname}</strong>님이 게시글 "<span style={{fontWeight:'bold'}}>{notification.board_title}</span>"에 댓글을 남겼습니다: <em>{notification.comment_content}</em>
-          </span>
+          <div className='noti-all' style={{cursor:'pointer'}} 
+          onClick={()=>{goToNotificationPost(notification.board_writer,notification.notification_board, notification.notification_comment)}}>
+            <strong className='notification-name' onClick={()=>{navigate(`/${notification.trigger_nickname}`)}}>{notification.trigger_nickname}</strong>
+            님이 게시글 "
+            <span style={{fontWeight:'bold'}} className='noti-title'>{truncateText(notification.board_title || '', 20)}</span>"
+            에 댓글을 남겼습니다: 
+            <em className='noti-title'>{truncateText(notification.comment_content || '', 20)}</em>
+          </div>
         );
       case 'reply-to-comment':
         return (
-          <span style={{cursor:'pointer'}} onClick={()=>{goToNotificationPost(notification.trigger_nickname,notification.notification_board)}}>
-            <strong className='notification-name' > {notification.trigger_nickname}</strong>님이 당신의 댓글에 답글을 남겼습니다: <em>{notification.comment_content}</em>
-          </span>
+          <div className='noti-all' style={{cursor:'pointer'}} 
+          onClick={()=>{goToNotificationPost(notification.board_writer,notification.notification_board,notification.parent_comment_id,notification.notification_comment)}}>
+            <strong className='notification-name' onClick={()=>{navigate(`/${notification.trigger_nickname}`)}}>
+               {truncateText(notification.trigger_nickname || '', 20)}</strong>
+            님이 게시글 "
+            <span style={{fontWeight:'bold'}} className='noti-title'>{truncateText(notification.board_title || '', 20)}</span>"
+            에 쓴 당신의 댓글에 답글을 남겼습니다:
+            <em className='noti-title'>{truncateText(notification.comment_content || '', 20)}</em>
+          </div>
         );
       case 'broadcast':
         return <span>새로운 공지가 있습니다.</span>;
       case 'board-new-like':
         return (
-          <span onClick={()=>{goToNotificationPost(localNickName,notification.notification_board)}} style={{cursor:'pointer'}}>
-            <strong className='notification-name' >{notification.trigger_nickname}</strong>님이 당신의 게시글을 좋아합니다: <em>{notification.board_title}</em>
-          </span>
+          <div className='noti-all' onClick={()=>{goToNotificationPost(notification.board_writer,notification.notification_board)}} style={{cursor:'pointer'}}>
+            <strong className='notification-name' onClick={()=>{navigate(`/${notification.trigger_nickname}`)}}>{notification.trigger_nickname}</strong>
+            님이 당신의 게시글을 좋아합니다:
+             <em className='noti-title'>{truncateText(notification.board_title || '', 20)}</em>
+          </div>
         );
       default:
         return <span>새로운 알림이 있습니다.</span>;
@@ -134,8 +153,10 @@ const Notification: React.FC<FollowModalProps> = ({ onClose, buttonRef }) => {
 
   };
 
-  const goToNotificationPost = (name, location)=>{
-    navigate(`/${name}/${location}`);
+  const goToNotificationPost = (name, location, commentID?, replyID?)=>{
+    if(commentID && !replyID) navigate(`/${name}/${location}/${commentID}`);
+    else if(commentID && replyID) navigate(`/${name}/${location}/${commentID}/${replyID}`);
+    else navigate(`/${name}/${location}`);
     onClose();
   }
   const formatDate = (dateString: string): string => {
@@ -193,17 +214,26 @@ const Notification: React.FC<FollowModalProps> = ({ onClose, buttonRef }) => {
       return `${year}.${month}.${day} ${ampm} ${strHours}:${minutes}:${seconds}`;
     }
   };
+  const truncateText = (text: string, maxLength: number) => {
+    if (text.length > maxLength) {
+      return text.slice(0, maxLength) + '...';
+    }
+    return text;
+  };
   return (
     <div className="modal-overlay-notification" onClick={onClose}>
       <div
         className="modal-content-notification"
-        style={{ position: 'absolute', ...modalStyle }} // 위치 스타일 적용
+        // style={{ position: 'absolute', ...modalStyle }}
         onClick={(e) => e.stopPropagation()}
       >
         
         <div className="modal-header-notification">
-        <h3 >새소식</h3>
-        <span className="allLook" onClick={goToAllNewNotification}>전체보기</span>
+
+        <div className='title-all'>
+          <h3>새소식</h3>
+          <span className="allLook" onClick={goToAllNewNotification}>전체보기</span>
+        </div>
         <span className="modal-close-notification" onClick={onClose}>
           &times;
         </span>

--- a/src/main/Profile.tsx
+++ b/src/main/Profile.tsx
@@ -363,7 +363,7 @@ const Profile: React.FC<ProfileProps> = ({ pageType,otherEmail,nicknameParam,use
       </section>
       )}
     {pageType === 'profileSetting' && (
-        <section className='profile-section-profileSetting'>
+        <section className='profile-section-myBlog'>
          <div className="profile-container">
           <img 
             src={image || mainCharacterImg} 

--- a/src/main/SSEComponent.css
+++ b/src/main/SSEComponent.css
@@ -4,7 +4,7 @@
     right: 20px;
     width: 300px;
     padding: 10px 20px;
-    background-color: rgba(251, 162, 226, 0.553); /* 알림창의 배경색 */
+    background-color: rgba(251, 162, 226, 0.757); /* 알림창의 배경색 */
     color: #fff; /* 알림창의 글자색 */
     border-radius: 8px;
     box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
@@ -35,7 +35,11 @@
   background-color: transparent;
   color: #fff; /* 알림창 내용의 글자색 */
   }
-  
+  .notification-content-message{
+    color: white;
+    background-color: transparent;
+    cursor: pointer;
+  }
   .close-btn-SSE  {
     background: none;
   border: none;

--- a/src/myblog/ManagePost/FixPost.tsx
+++ b/src/myblog/ManagePost/FixPost.tsx
@@ -31,6 +31,7 @@ const FixPost: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
+  const [hasNotifications, setHasNotifications] = useState<boolean>(false);
   const newImages: File[] = [];
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -141,6 +142,9 @@ const FixPost: React.FC = () => {
       return newImages;
     }
     return [];
+  };
+  const handleNotification = (isNotified: boolean) => {
+    setHasNotifications(isNotified); // 알림이 발생하면 true로 설정
   };
   const fixPosts = async () => {
 
@@ -324,7 +328,7 @@ const FixPost: React.FC = () => {
 
   return (
     <div className="App">
-      <Header pageType="otherblog" />
+      <Header pageType="otherblog" hasNotifications ={hasNotifications}/>
       <main className="write-new-post">
         <div className="dropdown" ref={dropdownRef} style={{ width: '300px' }}>
           <button className="dropdown-toggle" onClick={() => setDropdownOpen(!dropdownOpen)}>
@@ -419,7 +423,7 @@ const FixPost: React.FC = () => {
             </Button>
           </div>
         </Form>
-        <SSEComponent></SSEComponent>
+        <SSEComponent onNotification={handleNotification}></SSEComponent>
       </main>
       <Footer />
     </div>

--- a/src/myblog/ManagePost/GetPost.tsx
+++ b/src/myblog/ManagePost/GetPost.tsx
@@ -37,6 +37,7 @@ const GetPost: React.FC = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedPostId, setSelectedPostId] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState<string>('');
+  const [hasNotifications, setHasNotifications] = useState<boolean>(false);
   // const [filteredPosts, setFilteredPosts] = useState<TYPES.getPost[]>([]);
   const navigate = useNavigate();
 
@@ -344,6 +345,9 @@ const GetPost: React.FC = () => {
       setCursor('');
       fetchPosts(undefined,category.category_id,searchTerm);
   }, [category]);
+  const handleNotification = (isNotified: boolean) => {
+    setHasNotifications(isNotified); // 알림이 발생하면 true로 설정
+  };
   return (
     <div className="App">
    
@@ -352,7 +356,7 @@ const GetPost: React.FC = () => {
         <div>로딩 중...</div> // 전체 페이지 로딩 상태 시 표시될 내용
       ) : (
         <>
-       <Header pageType="otherblog" />
+       <Header pageType="otherblog" hasNotifications ={hasNotifications}/>
         <main className="blog-main-container">
       
           <Profile 
@@ -503,7 +507,7 @@ const GetPost: React.FC = () => {
             
           </section>
       
-        <SSEComponent></SSEComponent>
+        <SSEComponent onNotification={handleNotification}></SSEComponent>
       </main>
         </>
       )}

--- a/src/myblog/ManagePost/WriteNewPost.tsx
+++ b/src/myblog/ManagePost/WriteNewPost.tsx
@@ -27,6 +27,7 @@ const WriteNewPost: React.FC = () => {
   const [images, setImages] = useState<File[]>([]);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const [hasNotifications, setHasNotifications] = useState<boolean>(false);
   const [newPostResult, setNewPostResult] = useState<boolean | null>(null);
   const navigate = useNavigate();
   const newImages: File[] = [];
@@ -303,7 +304,9 @@ const WriteNewPost: React.FC = () => {
     //   alert("글 저장에 실패했습니다!!");
     // }
   }, [newPostResult, navigate]);
-
+  const handleNotification = (isNotified: boolean) => {
+    setHasNotifications(isNotified); // 알림이 발생하면 true로 설정
+  };
   useEffect(() => {
     console.log('Updated images in useEffect:', images);
   }, [images]);
@@ -330,7 +333,7 @@ const WriteNewPost: React.FC = () => {
 
   return (
     <div className="App">
-      <Header pageType="otherblog" />
+      <Header pageType="otherblog" hasNotifications ={hasNotifications}/>
       <main className="write-new-post">
         <div className="dropdown" ref={dropdownRef} style={{ width: '300px' }}>
           <button className="dropdown-toggle" onClick={() => setDropdownOpen(!dropdownOpen)}>
@@ -436,7 +439,7 @@ const WriteNewPost: React.FC = () => {
             </Button>
           </div>
         </Form>
-        <SSEComponent></SSEComponent>
+        <SSEComponent onNotification={handleNotification}></SSEComponent>
       </main>
       <Footer />
     </div>

--- a/src/myblog/MyBlogMainPage.tsx
+++ b/src/myblog/MyBlogMainPage.tsx
@@ -16,6 +16,7 @@ import SSEComponent from '../main/SSEComponent';
  */
 const MyBlogMainPage: React.FC = () => {
   const navigate = useNavigate();
+  const [hasNotifications, setHasNotifications] = useState<boolean>(false);
   let { nickname, postID } = useParams<{ nickname: string; postID?: string }>();
   const [categories, setCategories] = useState<Categories[]>([]);
   const [categoryID, setCategoryID] = useState<string>();
@@ -112,7 +113,9 @@ const MyBlogMainPage: React.FC = () => {
     fetchCategories();
   
   }, [navigate, nickname]);
-
+  const handleNotification = (isNotified: boolean) => {
+    setHasNotifications(isNotified); // 알림이 발생하면 true로 설정
+  };
   return (
     <div className="App">
 
@@ -120,8 +123,8 @@ const MyBlogMainPage: React.FC = () => {
         <div>로딩 중...</div> // 전체 페이지 로딩 상태 시 표시될 내용
       ) : (
         <>
-          {(localNickName === nickname) && <Header pageType="myBlog" />}
-          {(localNickName !== nickname) && <Header pageType="otherblog" />}
+          {(localNickName === nickname) && <Header pageType="myBlog" hasNotifications ={hasNotifications}/>}
+          {(localNickName !== nickname) && <Header pageType="otherblog" hasNotifications ={hasNotifications}/>}
 
           <main>
             
@@ -232,7 +235,7 @@ const MyBlogMainPage: React.FC = () => {
                 </>
                
               )}
-              <SSEComponent></SSEComponent>
+              <SSEComponent onNotification={handleNotification}></SSEComponent>
             
           
           </main>

--- a/src/structure/Header.tsx
+++ b/src/structure/Header.tsx
@@ -8,20 +8,27 @@ import UserProfile from './UserProfile';
 import no_notification from '../img/no_notification.png';
 import has_notification from '../img/has_notification.png';
 import Notification from '../main/Notification';
+import SSEComponent from '../main/SSEComponent';
+import { useNotification } from '../NotificationContext';
+
 interface ProfileProps {
   pageType: 'profileSetting'|'signup'|'logout' | 'otherblog'| 'myBlog';
+  hasNotifications?:boolean
 }
-const Header: React.FC<ProfileProps> = ({pageType}) => {
+const Header: React.FC<ProfileProps> = ({pageType ,hasNotifications = false}) => {
   const notificationButtonRef = useRef<HTMLDivElement>(null); // 알림 버튼 참조
   const [nickname, setNickname] = useState<string>();
   const [message, setMessage] = useState<string>('');
   const [image, setImage] = useState<string>(mainCharacterImg);
   const [isImageLoaded, setIsImageLoaded] = useState<boolean>(false);
+  const { hasNoti, setHasNoti } = useNotification(); // 전역 상태 사용
   const [token, setToken] = useState<string>('');
   const [openNotification, setOpenNotification]  = useState<boolean>(false);
-  
+
+
   const closeModal = () => {
     setOpenNotification(false);
+    setHasNoti(false);
   };
 
   useEffect(() => {
@@ -58,7 +65,48 @@ const Header: React.FC<ProfileProps> = ({pageType}) => {
         document.removeEventListener('keydown', handleKeyDown);
     };
     }
+
+    
+
   }, []);
+  useEffect(()=>{
+      console.log(`
+        
+        
+        header
+        
+        
+        hasNotifications
+        
+        
+        `,hasNotifications)
+        if(hasNotifications===true)setHasNoti(hasNotifications);
+        
+  },[hasNotifications])
+
+  useEffect(()=>{
+    console.log(`
+        
+
+
+
+
+
+
+
+        [hasNoti];
+
+
+
+
+
+
+
+      
+      
+      `,hasNoti)
+  },[hasNoti]);
+
 
   useEffect(() => {
     if (image) {
@@ -107,7 +155,11 @@ const Header: React.FC<ProfileProps> = ({pageType}) => {
             {openNotification && notificationButtonRef.current && (
               <Notification onClose={closeModal} buttonRef={notificationButtonRef} />
             )}
-            <img src={no_notification}  style={{width:'20px', height:'auto', marginRight:'20px'}}/>
+            {hasNoti ?
+              <img src={ has_notification}  style={{width:'20px', height:'auto', marginRight:'20px'}}/>
+             :<img src={ no_notification}  style={{width:'20px', height:'auto', marginRight:'20px'}}/>
+            }
+           
           </div>
             {profileImage && <UserProfile profileType={'logout'} profileImage={profileImage}></UserProfile>}
           </div>
@@ -131,7 +183,10 @@ const Header: React.FC<ProfileProps> = ({pageType}) => {
             {openNotification && notificationButtonRef.current && (
               <Notification onClose={closeModal} buttonRef={notificationButtonRef} />
             )}
-            <img src={no_notification}  style={{width:'20px', height:'auto', marginRight:'20px'}}/>
+            {hasNoti ?
+              <img src={ has_notification}  style={{width:'20px', height:'auto', marginRight:'20px'}}/>
+             :<img src={ no_notification}  style={{width:'20px', height:'auto', marginRight:'20px'}}/>
+            }
           </div>
           {profileImage && <UserProfile profileType={'logout'} profileImage={profileImage}></UserProfile>}
           </div>
@@ -155,7 +210,10 @@ const Header: React.FC<ProfileProps> = ({pageType}) => {
             {openNotification && notificationButtonRef.current && (
               <Notification onClose={closeModal} buttonRef={notificationButtonRef} />
             )}
-            <img src={no_notification}  style={{width:'20px', height:'auto', marginRight:'20px'}}/>
+            {hasNoti ?
+              <img src={ has_notification}  style={{width:'20px', height:'auto', marginRight:'20px'}}/>
+             :<img src={ no_notification}  style={{width:'20px', height:'auto', marginRight:'20px'}}/>
+            }
           </div>
           {profileImage && <UserProfile profileType={'otherblog'} profileImage={profileImage}></UserProfile>}
           </div>
@@ -179,7 +237,10 @@ const Header: React.FC<ProfileProps> = ({pageType}) => {
             {openNotification && notificationButtonRef.current && (
               <Notification onClose={closeModal} buttonRef={notificationButtonRef} />
             )}
-            <img src={no_notification}  style={{width:'20px', height:'auto', marginRight:'20px'}}/>
+            {hasNoti ?
+              <img src={ has_notification}  style={{width:'20px', height:'auto', marginRight:'20px'}}/>
+             :<img src={ no_notification}  style={{width:'20px', height:'auto', marginRight:'20px'}}/>
+            }
           </div>
           {profileImage && <UserProfile profileType={'myBlog'} profileImage={profileImage}></UserProfile>}
           </div>


### PR DESCRIPTION
…림 전체보기 페이지 반응형으로 개선

## 🌎 PR 요약

<img width="583" alt="스크린샷 2024-09-09 오전 1 09 39" src="https://github.com/user-attachments/assets/a59e60f5-9528-402f-a1ea-82fa13c61c13">
<img width="531" alt="스크린샷 2024-09-10 오전 1 19 59" src="https://github.com/user-attachments/assets/4ab85caf-8093-4c57-95fe-7a738a7c79bb">

 **- 실시간 알림창 투명도를 줄이고, 제목이 길경우 줄이고 선명하게 표시 및 프로필 이미지 없을 시 메인캐릭터로 대체**

<img width="766" alt="스크린샷 2024-09-09 오후 12 10 39" src="https://github.com/user-attachments/assets/2e9ee553-abee-4d95-a313-54c1d1966c11">
<img width="536" alt="스크린샷 2024-09-10 오전 1 20 45" src="https://github.com/user-attachments/assets/dc9f8a95-741d-4e00-9804-ae75b03fac75">

**-새소식 전체보기 페이지 반응형으로 개선 및 제목 어귀 등 ui 개선**

<img width="475" alt="스크린샷 2024-09-08 오후 9 15 24" src="https://github.com/user-attachments/assets/d4c68597-2287-4cdc-b437-15709c35c8a0">
<img width="544" alt="스크린샷 2024-09-10 오전 1 17 01" src="https://github.com/user-attachments/assets/698dbdee-1a66-47af-89bd-881388c111a7">

**-새소식 미니 페이지 반응형으로 개선 및 실시간 알림 시 헤어의 알림모양 이모티콘을 알림표시 이모티콘으로 즉시 변경 및 창 닫을 시 원래 이모티콘으로 재변경**

## 🔍 PR 유형

- [x] ♻️ 리팩토링 (기능 변경 없음, API 변경 없음)

## 📝 작업 내용


 **- 실시간 알림창 투명도를 줄이고, 제목이 길경우 줄이고 선명하게 표시 및 프로필 이미지 없을 시 메인캐릭터로 대체**

**-새소식 전체보기 페이지 반응형으로 개선 및 제목 어귀 등 ui 개선**

**-새소식 미니 페이지 반응형으로 개선 및 실시간 알림 시 헤어의 알림모양 이모티콘을 알림표시 이모티콘으로 즉시 변경 및 창 닫을 시 원래 이모티콘으로 재변경**



## 📍 참고 사항

## #️⃣ 연관된 이슈